### PR TITLE
Align two-column form inputs horizontally

### DIFF
--- a/src/components/dcr-calculator.tsx
+++ b/src/components/dcr-calculator.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ComponentProps } from "react";
+import { useMemo, useState, type ComponentProps, type ReactNode } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -99,6 +99,26 @@ const enginePresets: EnginePreset[] = [
     deckHeight: 1,
   },
 ];
+
+const alignedFormGridClass = "grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-6";
+
+const alignedFormItemClass = "row-span-4 grid grid-rows-subgrid gap-2";
+
+function FieldHelp({ children }: { children?: ReactNode }) {
+  if (!children) {
+    return <div aria-hidden="true" />;
+  }
+
+  return <FormDescription className="text-xs">{children}</FormDescription>;
+}
+
+function FieldErrorSlot() {
+  return (
+    <div>
+      <FormMessage />
+    </div>
+  );
+}
 
 function formatCamPresetTooltip(preset: CamPreset): string {
   let text = `${preset.intakeDuration}° @ 0.050" | ${preset.lsa}° LSA`;
@@ -396,12 +416,12 @@ export function DCRCalculator() {
 
             <div>
               <h3 className="text-sm font-semibold mb-3">Required — paper data points</h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className={alignedFormGridClass}>
                 <FormField
                   control={form.control}
                   name="stroke"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem>
+                    <FormItem className={alignedFormItemClass}>
                       <FormLabel>Stroke (mm)</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -410,7 +430,8 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FormMessage />
+                      <FieldHelp />
+                      <FieldErrorSlot />
                     </FormItem>
                   )}
                 />
@@ -418,7 +439,7 @@ export function DCRCalculator() {
                   control={form.control}
                   name="staticCR"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem>
+                    <FormItem className={alignedFormItemClass}>
                       <FormLabel>Static CR</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -427,10 +448,10 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FormDescription className="text-xs">
+                      <FieldHelp>
                         From piston spec sheet, or computed when bore + deck + chamber are filled
-                      </FormDescription>
-                      <FormMessage />
+                      </FieldHelp>
+                      <FieldErrorSlot />
                     </FormItem>
                   )}
                 />
@@ -438,7 +459,7 @@ export function DCRCalculator() {
                   control={form.control}
                   name="intakeDuration"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem>
+                    <FormItem className={alignedFormItemClass}>
                       <FormLabel>Intake Duration @ 0.050&quot; (deg)</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -448,7 +469,8 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FormMessage />
+                      <FieldHelp />
+                      <FieldErrorSlot />
                     </FormItem>
                   )}
                 />
@@ -456,7 +478,7 @@ export function DCRCalculator() {
                   control={form.control}
                   name="lsa"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem>
+                    <FormItem className={alignedFormItemClass}>
                       <FormLabel>Lobe Separation Angle (deg)</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -465,7 +487,8 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FormMessage />
+                      <FieldHelp />
+                      <FieldErrorSlot />
                     </FormItem>
                   )}
                 />
@@ -482,12 +505,12 @@ export function DCRCalculator() {
               </button>
 
               {showOptional && (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className={alignedFormGridClass}>
                   <FormField
                     control={form.control}
                     name="rodLength"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Rod Length (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -496,10 +519,10 @@ export function DCRCalculator() {
                             placeholder="Estimated if blank"
                           />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           SC / 3.2 rods: 127.8 mm C-C
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -507,7 +530,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="intakeDurationAt1mm"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Intake Duration @ 1 mm (deg)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -516,10 +539,10 @@ export function DCRCalculator() {
                             placeholder="Seat-to-seat / @ 1 mm"
                           />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           DRC card lists this — refines when the seat closes
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -527,7 +550,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="camAdvance"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Cam Advance (deg)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -537,10 +560,10 @@ export function DCRCalculator() {
                             step="0.5"
                           />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           Positive = advanced (intake closes earlier)
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -548,7 +571,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="overlapLiftMM"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Overlap Lift Setting (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -558,10 +581,10 @@ export function DCRCalculator() {
                             step="0.1"
                           />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           Requires nominal overlap lift to apply
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -569,7 +592,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="overlapLiftNominalMM"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Nominal Overlap Lift (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -579,7 +602,8 @@ export function DCRCalculator() {
                             step="0.1"
                           />
                         </FormControl>
-                        <FormMessage />
+                        <FieldHelp />
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -587,7 +611,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="intakeValveClosingAbdc"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>IVC ABDC (deg)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -597,10 +621,10 @@ export function DCRCalculator() {
                             step="0.5"
                           />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           Most accurate — overrides all IVC estimates
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -608,12 +632,13 @@ export function DCRCalculator() {
                     control={form.control}
                     name="bore"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Bore (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FormMessage />
+                        <FieldHelp />
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -621,12 +646,13 @@ export function DCRCalculator() {
                     control={form.control}
                     name="deckHeight"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Deck Height (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FormMessage />
+                        <FieldHelp />
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -634,12 +660,13 @@ export function DCRCalculator() {
                     control={form.control}
                     name="gasketThicknessMM"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Head Gasket Thickness (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FormMessage />
+                        <FieldHelp />
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -647,15 +674,15 @@ export function DCRCalculator() {
                     control={form.control}
                     name="headVolumeCC"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Combustion Chamber (cc)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           With bore + deck + chamber, overrides manual static CR on calculate
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />
@@ -663,15 +690,15 @@ export function DCRCalculator() {
                     control={form.control}
                     name="pistonCrownVolumeCC"
                     render={({ field }) => (
-                      <FormItem>
+                      <FormItem className={alignedFormItemClass}>
                         <FormLabel>Piston Crown Volume (cc)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FormDescription className="text-xs">
+                        <FieldHelp>
                           Dome (+) or dish (−) volume
-                        </FormDescription>
-                        <FormMessage />
+                        </FieldHelp>
+                        <FieldErrorSlot />
                       </FormItem>
                     )}
                   />

--- a/src/components/dcr-calculator.tsx
+++ b/src/components/dcr-calculator.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ComponentProps, type ReactNode } from "react";
+import { useMemo, useState, type ComponentProps } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -99,26 +99,6 @@ const enginePresets: EnginePreset[] = [
     deckHeight: 1,
   },
 ];
-
-const alignedFormGridClass = "grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-6";
-
-const alignedFormItemClass = "row-span-4 grid grid-rows-subgrid gap-2";
-
-function FieldHelp({ children }: { children?: ReactNode }) {
-  if (!children) {
-    return <div aria-hidden="true" />;
-  }
-
-  return <FormDescription className="text-xs">{children}</FormDescription>;
-}
-
-function FieldErrorSlot() {
-  return (
-    <div>
-      <FormMessage />
-    </div>
-  );
-}
 
 function formatCamPresetTooltip(preset: CamPreset): string {
   let text = `${preset.intakeDuration}° @ 0.050" | ${preset.lsa}° LSA`;
@@ -416,12 +396,12 @@ export function DCRCalculator() {
 
             <div>
               <h3 className="text-sm font-semibold mb-3">Required — paper data points</h3>
-              <div className={alignedFormGridClass}>
+              <div className="aligned-form-grid">
                 <FormField
                   control={form.control}
                   name="stroke"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem className={alignedFormItemClass}>
+                    <FormItem className="aligned-form-item">
                       <FormLabel>Stroke (mm)</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -430,8 +410,7 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FieldHelp />
-                      <FieldErrorSlot />
+                      <FormMessage />
                     </FormItem>
                   )}
                 />
@@ -439,7 +418,7 @@ export function DCRCalculator() {
                   control={form.control}
                   name="staticCR"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem className={alignedFormItemClass}>
+                    <FormItem className="aligned-form-item">
                       <FormLabel>Static CR</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -448,10 +427,10 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FieldHelp>
+                      <FormDescription className="text-xs">
                         From piston spec sheet, or computed when bore + deck + chamber are filled
-                      </FieldHelp>
-                      <FieldErrorSlot />
+                      </FormDescription>
+                      <FormMessage />
                     </FormItem>
                   )}
                 />
@@ -459,7 +438,7 @@ export function DCRCalculator() {
                   control={form.control}
                   name="intakeDuration"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem className={alignedFormItemClass}>
+                    <FormItem className="aligned-form-item">
                       <FormLabel>Intake Duration @ 0.050&quot; (deg)</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -469,8 +448,7 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FieldHelp />
-                      <FieldErrorSlot />
+                      <FormMessage />
                     </FormItem>
                   )}
                 />
@@ -478,7 +456,7 @@ export function DCRCalculator() {
                   control={form.control}
                   name="lsa"
                   render={({ field: { value, onChange, ...fieldProps } }) => (
-                    <FormItem className={alignedFormItemClass}>
+                    <FormItem className="aligned-form-item">
                       <FormLabel>Lobe Separation Angle (deg)</FormLabel>
                       <FormControl>
                         <RequiredNumberInput
@@ -487,8 +465,7 @@ export function DCRCalculator() {
                           {...fieldProps}
                         />
                       </FormControl>
-                      <FieldHelp />
-                      <FieldErrorSlot />
+                      <FormMessage />
                     </FormItem>
                   )}
                 />
@@ -505,12 +482,12 @@ export function DCRCalculator() {
               </button>
 
               {showOptional && (
-                <div className={alignedFormGridClass}>
+                <div className="aligned-form-grid">
                   <FormField
                     control={form.control}
                     name="rodLength"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Rod Length (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -519,10 +496,10 @@ export function DCRCalculator() {
                             placeholder="Estimated if blank"
                           />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           SC / 3.2 rods: 127.8 mm C-C
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -530,7 +507,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="intakeDurationAt1mm"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Intake Duration @ 1 mm (deg)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -539,10 +516,10 @@ export function DCRCalculator() {
                             placeholder="Seat-to-seat / @ 1 mm"
                           />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           DRC card lists this — refines when the seat closes
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -550,7 +527,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="camAdvance"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Cam Advance (deg)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -560,10 +537,10 @@ export function DCRCalculator() {
                             step="0.5"
                           />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           Positive = advanced (intake closes earlier)
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -571,7 +548,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="overlapLiftMM"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Overlap Lift Setting (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -581,10 +558,10 @@ export function DCRCalculator() {
                             step="0.1"
                           />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           Requires nominal overlap lift to apply
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -592,7 +569,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="overlapLiftNominalMM"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Nominal Overlap Lift (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -602,8 +579,7 @@ export function DCRCalculator() {
                             step="0.1"
                           />
                         </FormControl>
-                        <FieldHelp />
-                        <FieldErrorSlot />
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -611,7 +587,7 @@ export function DCRCalculator() {
                     control={form.control}
                     name="intakeValveClosingAbdc"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>IVC ABDC (deg)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput
@@ -621,10 +597,10 @@ export function DCRCalculator() {
                             step="0.5"
                           />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           Most accurate — overrides all IVC estimates
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -632,13 +608,12 @@ export function DCRCalculator() {
                     control={form.control}
                     name="bore"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Bore (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FieldHelp />
-                        <FieldErrorSlot />
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -646,13 +621,12 @@ export function DCRCalculator() {
                     control={form.control}
                     name="deckHeight"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Deck Height (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FieldHelp />
-                        <FieldErrorSlot />
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -660,13 +634,12 @@ export function DCRCalculator() {
                     control={form.control}
                     name="gasketThicknessMM"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Head Gasket Thickness (mm)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FieldHelp />
-                        <FieldErrorSlot />
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -674,15 +647,15 @@ export function DCRCalculator() {
                     control={form.control}
                     name="headVolumeCC"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Combustion Chamber (cc)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           With bore + deck + chamber, overrides manual static CR on calculate
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />
@@ -690,15 +663,15 @@ export function DCRCalculator() {
                     control={form.control}
                     name="pistonCrownVolumeCC"
                     render={({ field }) => (
-                      <FormItem className={alignedFormItemClass}>
+                      <FormItem className="aligned-form-item">
                         <FormLabel>Piston Crown Volume (cc)</FormLabel>
                         <FormControl>
                           <OptionalNumberInput value={field.value} onChange={field.onChange} />
                         </FormControl>
-                        <FieldHelp>
+                        <FormDescription className="text-xs">
                           Dome (+) or dish (−) volume
-                        </FieldHelp>
-                        <FieldErrorSlot />
+                        </FormDescription>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />

--- a/src/index.css
+++ b/src/index.css
@@ -230,3 +230,44 @@ body {
     letter-spacing: var(--tracking-normal);
     }
 }
+
+@layer components {
+  .aligned-form-grid {
+    container-type: inline-size;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    column-gap: 1rem;
+    row-gap: 1.5rem;
+  }
+
+  @container (min-width: 28rem) {
+    .aligned-form-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .aligned-form-item {
+    display: grid;
+    grid-row: span 4;
+    grid-template-rows: subgrid;
+    gap: 0.5rem;
+  }
+
+  .aligned-form-item [data-slot="form-label"] {
+    grid-row: 1;
+    align-self: end;
+    text-wrap: balance;
+  }
+
+  .aligned-form-item [data-slot="form-control"] {
+    grid-row: 2;
+  }
+
+  .aligned-form-item [data-slot="form-description"] {
+    grid-row: 3;
+  }
+
+  .aligned-form-item [data-slot="form-message"] {
+    grid-row: 4;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes staggered inputs in the DCR calculator's two-column form layout. Labels and help text had different heights, so inputs in the same row did not line up horizontally.

## Approach

Uses modern CSS instead of React placeholder helpers:

- **Container queries** — `.aligned-form-grid` switches to two columns based on its own width (`@container (min-width: 28rem)`), not viewport breakpoints
- **CSS subgrid** — `.aligned-form-item` spans four shared rows (label, input, help, error) with the sibling column
- **`data-slot` placement** — explicit `grid-row` on form label, control, description, and message slots so optional help/error text does not require empty DOM nodes
- **`text-wrap: balance`** — multi-line labels distribute more evenly
- **`align-self: end`** — labels sit at the bottom of the shared label row so inputs align

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [ ] Visually confirm inputs align across columns when the form grid is wide enough
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2068-b284-72c7-a619-ffe07f63b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2068-b284-72c7-a619-ffe07f63b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

