### PR TITLE
Fix two-column form layout and input width

### DIFF
--- a/src/components/dcr-calculator.tsx
+++ b/src/components/dcr-calculator.tsx
@@ -396,7 +396,8 @@ export function DCRCalculator() {
 
             <div>
               <h3 className="text-sm font-semibold mb-3">Required — paper data points</h3>
-              <div className="aligned-form-grid">
+              <div className="aligned-form-section">
+                <div className="aligned-form-grid">
                 <FormField
                   control={form.control}
                   name="stroke"
@@ -469,6 +470,7 @@ export function DCRCalculator() {
                     </FormItem>
                   )}
                 />
+                </div>
               </div>
             </div>
 
@@ -482,7 +484,8 @@ export function DCRCalculator() {
               </button>
 
               {showOptional && (
-                <div className="aligned-form-grid">
+                <div className="aligned-form-section">
+                  <div className="aligned-form-grid">
                   <FormField
                     control={form.control}
                     name="rodLength"
@@ -675,6 +678,7 @@ export function DCRCalculator() {
                       </FormItem>
                     )}
                   />
+                  </div>
                 </div>
               )}
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -232,15 +232,19 @@ body {
 }
 
 @layer components {
-  .aligned-form-grid {
+  .aligned-form-section {
     container-type: inline-size;
+    container-name: aligned-form;
+  }
+
+  .aligned-form-grid {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     column-gap: 1rem;
     row-gap: 1.5rem;
   }
 
-  @container (min-width: 28rem) {
+  @container aligned-form (min-width: 20rem) {
     .aligned-form-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -251,6 +255,7 @@ body {
     grid-row: span 4;
     grid-template-rows: subgrid;
     gap: 0.5rem;
+    min-width: 0;
   }
 
   .aligned-form-item [data-slot="form-label"] {
@@ -261,6 +266,7 @@ body {
 
   .aligned-form-item [data-slot="form-control"] {
     grid-row: 2;
+    min-width: 0;
   }
 
   .aligned-form-item [data-slot="form-description"] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the two-column form layout after the merged alignment change collapsed fields into a single full-width column.

## Root cause

The previous CSS put `container-type: inline-size` on `.aligned-form-grid` and then used `@container` to style that same element. Container queries only evaluate **ancestor** containers — an element cannot query its own size — so the two-column rule never applied and every input stretched to full card width.

## Fix

- Add `.aligned-form-section` as a named size container wrapping each form grid
- Query `@container aligned-form (min-width: 20rem)` from the child `.aligned-form-grid`
- Keep subgrid alignment (`aligned-form-item`) unchanged
- Add `min-width: 0` on items/controls so grid columns size correctly

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [ ] Confirm required fields render in two columns at normal card width
- [ ] Confirm inputs align horizontally across columns (label/help height differences)
- [ ] Confirm single column on narrow viewports (< ~320px container width)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2068-b284-72c7-a619-ffe07f63b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2068-b284-72c7-a619-ffe07f63b8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

