### PR TITLE
Add 1966 Mustang drivetrain presets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import './App.css'
 import { DCRCalculator } from './components/dcr-calculator'
+import { DrivetrainPresets } from './components/drivetrain-presets'
 
 function App() {
   return (
@@ -10,7 +11,10 @@ function App() {
           Calculate Dynamic Compression Ratio based on camshaft specs & valve timing.
         </p>
       </header>
-      <DCRCalculator />
+      <div className="space-y-6">
+        <DCRCalculator />
+        <DrivetrainPresets />
+      </div>
     </div>
   )
 }

--- a/src/components/drivetrain-presets.tsx
+++ b/src/components/drivetrain-presets.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  calculateOverallFirstGearRatio,
+  drivetrainPresets,
+  type DrivetrainPreset,
+} from "@/lib/drivetrain-presets";
+
+export function DrivetrainPresets() {
+  const [selectedPreset, setSelectedPreset] = useState<DrivetrainPreset | null>(null);
+
+  const handlePresetChange = (value: string) => {
+    setSelectedPreset(drivetrainPresets.find((preset) => preset.name === value) ?? null);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-center text-lg">Drivetrain Presets</CardTitle>
+        <CardDescription className="text-center text-xs">
+          Saved reference gearing for the 1966 Mustang build.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Select onValueChange={handlePresetChange}>
+          <SelectTrigger className="w-full font-mono bg-muted">
+            <SelectValue placeholder="Drivetrain preset…" />
+          </SelectTrigger>
+          <SelectContent className="font-mono">
+            {drivetrainPresets.map((preset) => (
+              <SelectItem key={preset.name} value={preset.name}>
+                {preset.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {selectedPreset && (
+          <div className="grid gap-2 border-2 border-border bg-secondary p-4 text-sm sm:grid-cols-4">
+            <div>
+              <p className="text-xs text-muted-foreground">Transmission</p>
+              <p className="font-semibold">{selectedPreset.transmission}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">First gear</p>
+              <p className="font-semibold">{selectedPreset.firstGearRatio.toFixed(2)}:1</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Rear ratio</p>
+              <p className="font-semibold">{selectedPreset.finalDriveRatio.toFixed(2)}:1</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Overall first</p>
+              <p className="font-semibold">
+                {calculateOverallFirstGearRatio(selectedPreset).toFixed(2)}:1
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/drivetrain-presets.test.ts
+++ b/src/lib/drivetrain-presets.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateOverallFirstGearRatio,
+  drivetrainPresets,
+} from "./drivetrain-presets";
+
+describe("drivetrain presets", () => {
+  it("includes both 1966 Mustang T5 final-drive options", () => {
+    expect(drivetrainPresets.map((preset) => preset.name)).toEqual([
+      "’66 Mustang (T5 w/ 2.95 1st, 3.55 rear)",
+      "’66 Mustang (T5 w/ 2.95 1st, 3.80 rear)",
+    ]);
+  });
+
+  it("calculates overall first-gear ratios", () => {
+    expect(calculateOverallFirstGearRatio(drivetrainPresets[0])).toBeCloseTo(10.4725, 4);
+    expect(calculateOverallFirstGearRatio(drivetrainPresets[1])).toBeCloseTo(11.21, 2);
+  });
+});

--- a/src/lib/drivetrain-presets.ts
+++ b/src/lib/drivetrain-presets.ts
@@ -1,0 +1,25 @@
+export type DrivetrainPreset = {
+  name: string;
+  transmission: string;
+  firstGearRatio: number;
+  finalDriveRatio: number;
+};
+
+export const drivetrainPresets: DrivetrainPreset[] = [
+  {
+    name: "’66 Mustang (T5 w/ 2.95 1st, 3.55 rear)",
+    transmission: "T5",
+    firstGearRatio: 2.95,
+    finalDriveRatio: 3.55,
+  },
+  {
+    name: "’66 Mustang (T5 w/ 2.95 1st, 3.80 rear)",
+    transmission: "T5",
+    firstGearRatio: 2.95,
+    finalDriveRatio: 3.8,
+  },
+];
+
+export function calculateOverallFirstGearRatio(preset: DrivetrainPreset): number {
+  return preset.firstGearRatio * preset.finalDriveRatio;
+}


### PR DESCRIPTION
Closed because this change was intended for `elithrar/get-ratioed`, not `dcr-calculator`.